### PR TITLE
Adds entitlement and profile checking, fixes other complaints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 package-lock.json
 .vscode
+
+*-cache.json

--- a/README.md
+++ b/README.md
@@ -11,121 +11,72 @@ Quickly and easily obtain an xbox token to authenticate with Minecraft/Mojang
 npm install prismarine-auth
 ```
 
-## Getting A Minecraft Java Token
+## Usage
 
-### Device Code Authentication
+**Parameters**
+- username {String} - Username for authentication
+- cacheDirectory {String} - Where we will store your tokens
+- options {Object?}
+    - [password] {string} - If passed we will do password based authentication.
+    - [authTitle] {string} - Required to switch to live.com authentication and do title authentication. Needed for accounts with a date of birth under 18 years old.
+    - [fetchEntitlements] {boolean} - Fetches all if any entitlements that might be attached to your minecraft java token.
+    - [fetchProfile] {boolean} - Fetches your minecraft java profile (if any)
+- onMsaCode {Function} - What we should do when we get the code. Useful for passing the code to another function.
+
+[View more examples](https://github.com/PrismarineJS/prismarine-auth/tree/master/examples)
+
+
+### Device Code Example
 ```js
 const { Authflow } = require('prismarine-auth');
 
 const doAuth = async() => {
-    const flow = new Authflow('mineflayer@is.cool', './')
-    const XSTSToken = await flow.getMinecraftJavaToken()
-    console.log(XSTSToken)
-}
-
-doAuth()
-```
-
-### Password-based Authentication
-```js
-const { Authflow } = require('prismarine-auth');
-
-const doAuth = async() => {
-    const flow = new Authflow('mineflayer@is.cool', './', { password: 'thisIsAFakePassword123'})
-    const XSTSToken = await flow.getMinecraftJavaToken()
-    console.log(XSTSToken)
-}
-
-doAuth()
-```
-
-## Getting A Minecraft Bedrock Token
-When authenticating for minecraft bedrock edition, you have to generate and send a signed certificate to the bedrock server.
-This function handles logging into Xbox Live, posting its public key to the Mojang API, and using the returned certificate signed by Mojang.
-
-### Device Code Authentication
-```js
-const { Authflow } = require('prismarine-auth');
-const crypto = require('crypto')
-const curve = 'secp384r1'
-
-const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
-const doAuth = async() => {
-    const flow = new Authflow('mineflayer@is.cool', './')
-    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
-    console.log(XSTSToken)
-}
-
-doAuth()
-```
-
-### Password Authentication:
-```js
-const { Authflow } = require('prismarine-auth');
-const crypto = require('crypto')
-const curve = 'secp384r1'
-
-const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
-
-const doAuth = async() => {
-    const flow = new Authflow('mineflayer@is.cool', './', { password: 'thisIsAFakePassword123'})
-    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
-    console.log(XSTSToken)
-}
-
-doAuth()
-```
-
-## Live.com Authentication with Titles
-
-### Device Code Authentication
-```js
-const { Authflow, Titles } = require('prismarine-auth');
-const crypto = require('crypto')
-const curve = 'secp384r1'
-
-const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
-const doAuth = async() => {
-    const flow = new Authflow('mineflayer@is.cool', './', { authTitle: Titles.MinecraftNintendoSwitch })
-    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
-    console.log(XSTSToken)
-}
-
-doAuth()
-```
-
-### Password Authentication
-```js
-const { Authflow , Titles} = require('prismarine-auth');
-const crypto = require('crypto')
-const curve = 'secp384r1'
-
-const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
-
-const doAuth = async() => {
-    const flow = new Authflow('mineflayer@is.cool', './', { password: 'thisIsAFakePassword123', authTitle: Titles.MinecraftJava })
-    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
-    console.log(XSTSToken)
+    const flow = new Authflow('i@heart.mineflayer', process.cwd(), { fetchProfile: true })
+    const response = await flow.getMinecraftJavaToken()
+    console.log(response)
 }
 
 doAuth()
 ```
 
 ### Expected Response
-```php
+```json
 {
-    "userXUID": "2584878536129841", // May be null
-    "userHash": "3218841136841218711",
-    "XSTSToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiWGJveFJlcGxheS5uZXQifQ.c2UraxPmZ4STYozrjFEW8SBqU0WjnIV0h-jjnfsKtrA",
-    "expiresOn": "2020-04-13T05:43:32.6275675Z"
+    "token": "ey....................",
+    "entitlements": {},
+    "profile": {
+        "id": "b945b6ed99b548675309473a69661b9a",
+        "name": "Usname",
+        "skins": [ [Object] ],
+        "capes": []
+    }
 }
 ```
 
-### Parameters
-Authflow class
-- username {String} - Username for authentication
-- cacheDirectory {String} - Where we will store your tokens
-- options {Object?}
-    - [password] {string} - If passed we will do password based authentication.
-    - [authTitle] {string} - Required to switch to live.com authentication and do title authentication. Needed for accounts with a date of birth under 18 years old.
-- onMsaCode {Function} - What we should do when we get the code. Useful for passing the code to another function.
+## Debugging
+
+You can enable some debugging output using the `DEBUG` enviroment variable.
+
+**Linux**
+```bash
+DEBUG="prismarine-auth" node [...]
+```
+
+**Windows Powershell**
+```powershell
+$env:DEBUG = "prismarine-auth";node [...]
+```
+
+**Windows CMD**
+```cmd
+set DEBUG="prismarine-auth"
+node [...]
+```
+
+## Testing
+
+Simply run `npm test` or `yarn test`
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ npm install prismarine-auth
 - options {Object?}
     - [password] {string} - If passed we will do password based authentication.
     - [authTitle] {string} - Required to switch to live.com authentication and do title authentication. Needed for accounts with a date of birth under 18 years old.
-    - [fetchEntitlements] {boolean} - Fetches all if any entitlements that might be attached to your minecraft java token.
-    - [fetchProfile] {boolean} - Fetches your minecraft java profile (if any)
 - onMsaCode {Function} - What we should do when we get the code. Useful for passing the code to another function.
 
 [View more examples](https://github.com/PrismarineJS/prismarine-auth/tree/master/examples)

--- a/examples/bedrock/deviceCode.js
+++ b/examples/bedrock/deviceCode.js
@@ -1,17 +1,17 @@
-const { Authflow } = require('prismarine-auth');
+const { Authflow } = require('prismarine-auth')
 const crypto = require('crypto')
 const curve = 'secp384r1'
 
 if (process.argv.length !== 4) {
-    console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
-    process.exit(1)
+  console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
+  process.exit(1)
 }
 
-const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
-const doAuth = async() => {
-    const flow = new Authflow(process.argv[2], process.argv[3])
-    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
-    console.log(XSTSToken)
+const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64')
+const doAuth = async () => {
+  const flow = new Authflow(process.argv[2], process.argv[3])
+  const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
+  console.log(XSTSToken)
 }
 
 doAuth()

--- a/examples/bedrock/deviceCode.js
+++ b/examples/bedrock/deviceCode.js
@@ -1,0 +1,17 @@
+const { Authflow } = require('prismarine-auth');
+const crypto = require('crypto')
+const curve = 'secp384r1'
+
+if (process.argv.length !== 4) {
+    console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
+    process.exit(1)
+}
+
+const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
+const doAuth = async() => {
+    const flow = new Authflow(process.argv[2], process.argv[3])
+    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
+    console.log(XSTSToken)
+}
+
+doAuth()

--- a/examples/bedrock/password.js
+++ b/examples/bedrock/password.js
@@ -1,0 +1,17 @@
+const { Authflow } = require('prismarine-auth');
+const crypto = require('crypto')
+const curve = 'secp384r1'
+
+if (process.argv.length !== 5) {
+    console.log('Usage: node password.js <username> <password> <cacheDirectory>')
+    process.exit(1)
+}
+
+const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
+const doAuth = async() => {
+    const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3]})
+    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
+    console.log(XSTSToken)
+}
+
+doAuth()

--- a/examples/bedrock/password.js
+++ b/examples/bedrock/password.js
@@ -1,17 +1,17 @@
-const { Authflow } = require('prismarine-auth');
+const { Authflow } = require('prismarine-auth')
 const crypto = require('crypto')
 const curve = 'secp384r1'
 
 if (process.argv.length !== 5) {
-    console.log('Usage: node password.js <username> <password> <cacheDirectory>')
-    process.exit(1)
+  console.log('Usage: node password.js <username> <password> <cacheDirectory>')
+  process.exit(1)
 }
 
-const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
-const doAuth = async() => {
-    const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3]})
-    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
-    console.log(XSTSToken)
+const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64')
+const doAuth = async () => {
+  const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3] })
+  const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
+  console.log(XSTSToken)
 }
 
 doAuth()

--- a/examples/deviceCode.js
+++ b/examples/deviceCode.js
@@ -1,0 +1,14 @@
+const { Authflow } = require('../index');
+
+if (process.argv.length !== 4) {
+    console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
+    process.exit(1)
+}
+
+const doAuth = async() => {
+    const flow = new Authflow(process.argv[2], process.argv[3], { fetchProfile: true, fetchEntitlements: true })
+    const response = await flow.getMinecraftJavaToken()
+    console.log(response)
+}
+
+doAuth()

--- a/examples/deviceCode.js
+++ b/examples/deviceCode.js
@@ -7,7 +7,7 @@ if (process.argv.length !== 4) {
 
 const doAuth = async () => {
   const flow = new Authflow(process.argv[2], process.argv[3], { fetchProfile: true, fetchEntitlements: true })
-  const response = await flow.getMinecraftJavaToken()
+  const response = await flow.getMinecraftJavaToken({ fetchEntitlements: true, fetchProfile: true})
   console.log(response)
 }
 

--- a/examples/deviceCode.js
+++ b/examples/deviceCode.js
@@ -7,7 +7,7 @@ if (process.argv.length !== 4) {
 
 const doAuth = async () => {
   const flow = new Authflow(process.argv[2], process.argv[3], { fetchProfile: true, fetchEntitlements: true })
-  const response = await flow.getMinecraftJavaToken({ fetchEntitlements: true, fetchProfile: true})
+  const response = await flow.getMinecraftJavaToken({ fetchEntitlements: true, fetchProfile: true })
   console.log(response)
 }
 

--- a/examples/deviceCode.js
+++ b/examples/deviceCode.js
@@ -1,14 +1,14 @@
-const { Authflow } = require('../index');
+const { Authflow } = require('../index')
 
 if (process.argv.length !== 4) {
-    console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
-    process.exit(1)
+  console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
+  process.exit(1)
 }
 
-const doAuth = async() => {
-    const flow = new Authflow(process.argv[2], process.argv[3], { fetchProfile: true, fetchEntitlements: true })
-    const response = await flow.getMinecraftJavaToken()
-    console.log(response)
+const doAuth = async () => {
+  const flow = new Authflow(process.argv[2], process.argv[3], { fetchProfile: true, fetchEntitlements: true })
+  const response = await flow.getMinecraftJavaToken()
+  console.log(response)
 }
 
 doAuth()

--- a/examples/live/deviceCode.js
+++ b/examples/live/deviceCode.js
@@ -1,17 +1,17 @@
-const { Authflow, Titles } = require('prismarine-auth');
+const { Authflow, Titles } = require('prismarine-auth')
 const crypto = require('crypto')
 const curve = 'secp384r1'
 
 if (process.argv.length !== 4) {
-    console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
-    process.exit(1)
+  console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
+  process.exit(1)
 }
 
-const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
-const doAuth = async() => {
-    const flow = new Authflow(process.argv[2], process.argv[3], { authTitle: Titles.MinecraftNintendoSwitch })
-    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
-    console.log(XSTSToken)
+const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64')
+const doAuth = async () => {
+  const flow = new Authflow(process.argv[2], process.argv[3], { authTitle: Titles.MinecraftNintendoSwitch })
+  const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
+  console.log(XSTSToken)
 }
 
 doAuth()

--- a/examples/live/deviceCode.js
+++ b/examples/live/deviceCode.js
@@ -1,0 +1,17 @@
+const { Authflow, Titles } = require('prismarine-auth');
+const crypto = require('crypto')
+const curve = 'secp384r1'
+
+if (process.argv.length !== 4) {
+    console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
+    process.exit(1)
+}
+
+const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
+const doAuth = async() => {
+    const flow = new Authflow(process.argv[2], process.argv[3], { authTitle: Titles.MinecraftNintendoSwitch })
+    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
+    console.log(XSTSToken)
+}
+
+doAuth()

--- a/examples/live/password.js
+++ b/examples/live/password.js
@@ -1,18 +1,17 @@
-const { Authflow , Titles} = require('prismarine-auth');
+const { Authflow, Titles } = require('prismarine-auth')
 const crypto = require('crypto')
 const curve = 'secp384r1'
 
-
 if (process.argv.length !== 5) {
-    console.log('Usage: node password.js <username> <password> <cacheDirectory>')
-    process.exit(1)
+  console.log('Usage: node password.js <username> <password> <cacheDirectory>')
+  process.exit(1)
 }
 
-const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
-const doAuth = async() => {
-    const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3], authTitle: Titles.MinecraftJava })
-    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
-    console.log(XSTSToken)
+const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64')
+const doAuth = async () => {
+  const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3], authTitle: Titles.MinecraftJava })
+  const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
+  console.log(XSTSToken)
 }
 
 doAuth()

--- a/examples/live/password.js
+++ b/examples/live/password.js
@@ -1,0 +1,18 @@
+const { Authflow , Titles} = require('prismarine-auth');
+const crypto = require('crypto')
+const curve = 'secp384r1'
+
+
+if (process.argv.length !== 5) {
+    console.log('Usage: node password.js <username> <password> <cacheDirectory>')
+    process.exit(1)
+}
+
+const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64') 
+const doAuth = async() => {
+    const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3], authTitle: Titles.MinecraftJava })
+    const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
+    console.log(XSTSToken)
+}
+
+doAuth()

--- a/examples/password.js
+++ b/examples/password.js
@@ -1,0 +1,14 @@
+const { Authflow } = require('../index');
+
+if (process.argv.length !== 5) {
+    console.log('Usage: node password.js <username> <password> <cacheDirectory>')
+    process.exit(1)
+}
+
+const doAuth = async() => {
+    const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3]})
+    const response = await flow.getMinecraftJavaToken()
+    console.log(response)
+}
+
+doAuth()

--- a/examples/password.js
+++ b/examples/password.js
@@ -1,14 +1,14 @@
-const { Authflow } = require('../index');
+const { Authflow } = require('../index')
 
 if (process.argv.length !== 5) {
-    console.log('Usage: node password.js <username> <password> <cacheDirectory>')
-    process.exit(1)
+  console.log('Usage: node password.js <username> <password> <cacheDirectory>')
+  process.exit(1)
 }
 
-const doAuth = async() => {
-    const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3]})
-    const response = await flow.getMinecraftJavaToken()
-    console.log(response)
+const doAuth = async () => {
+  const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3] })
+  const response = await flow.getMinecraftJavaToken()
+  console.log(response)
 }
 
 doAuth()

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,35 @@
+/// <reference types="node" />
+
+declare module 'prismarine-auth' {
+    export class MicrosoftAuthFlow {
+        constructor(username: string, cache: string, options?: MicrosoftAuthFlowOptions, codeCallback?: Function)
+        initTokenCaches?: (username: string, cache: string) => void
+        resetTokenCaches?: (cache: string) => boolean
+        getMsaToken?: () => string
+        getXboxToken?: () => string
+        getMinecraftJavaToken?: (MinecraftJavaToken: object) => string
+        getMinecraftBedrockToken?: (publicKey: string) => string
+    }
+    export interface MinecraftJavaToken {
+        fetchEntitlements: boolean = false
+        fetchProfile: boolean = false
+    }
+
+    export interface MicrosoftAuthFlowOptions {
+        relyingParty?: RelyingParty
+        authTitle?: Titles
+        password?: String
+    }
+
+    export enum Titles {
+        MinecraftNintendoSwitch = '00000000441cc96b',
+        MinecraftJava = '00000000402b5328'
+    }
+
+    export enum RelyingParty {
+        PCXSTSRelyingParty = 'rp://api.minecraftservices.com/',
+        BedrockXSTSRelyingParty = 'https://multiplayer.minecraft.net/',
+        XboxXSTSRelyingParty = 'http://auth.xboxlive.com/'
+    }
+
+}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,5 @@ if (typeof process !== 'undefined' && parseInt(process.versions.node.split('.')[
 
 module.exports = {
   Authflow: require('./src/MicrosoftAuthFlow'),
-  Titles: require('./src/common/Titles'),
-  Endpoints: require('./src/common/Constants').Endpoints
+  Titles: require('./src/common/Titles')
 }

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -135,11 +135,18 @@ class MicrosoftAuthFlow {
   }
 
   /**
+   * @typedef {Object} JavaTokenOptions
+   * @property {boolean} [fetchEntitlements=false] Whether we should also fetch and return entitlements for this access token.
+   * @property {boolean} [fetchProfile=false] Whether we should also fetch and return profile for this access token.
+   */
+
+  /**
    * Gets either the cached, or fetchs a new minecraft java token.
+   * @param {JavaTokenOptions} [options = {}] fetchEntitlements, fetchProfile options
    * @returns {object}
    */
 
-  async getMinecraftJavaToken () {
+  async getMinecraftJavaToken (options = {}) {
     const response = { token: '', entitlements: {}, profile: {} }
     if (await this.mca.verifyTokens()) {
       debug('[mc] Using existing tokens')
@@ -154,10 +161,10 @@ class MicrosoftAuthFlow {
       }, () => { this.xbl.forceRefresh = true }, 2)
     }
 
-    if (this.options.fetchEntitlements) {
+    if (options.fetchEntitlements) {
       response.entitlements = await this.mca.fetchEntitlements(response.token)
     }
-    if (this.options.fetchProfile) {
+    if (options.fetchProfile) {
       response.profile = await this.mca.fetchProfile(response.token)
     }
 

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -143,7 +143,7 @@ class MicrosoftAuthFlow {
     const response = { token: '', entitlements: {}, profile: {} }
     if (await this.mca.verifyTokens()) {
       debug('[mc] Using existing tokens')
-      response.token =  this.mca.getCachedAccessToken().token
+      response.token = this.mca.getCachedAccessToken().token
     } else {
       this.xbl.relyingParty = Endpoints.PCXSTSRelyingParty
       debug('[mc] Need to obtain tokens')

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -150,7 +150,7 @@ class MicrosoftAuthFlow {
       await retry(async () => {
         const xsts = await this.getXboxToken()
         debug('[xbl] xsts data', xsts)
-        response.token = this.mca.getAccessToken(xsts)
+        response.token = await this.mca.getAccessToken(xsts)
       }, () => { this.xbl.forceRefresh = true }, 2)
     }
 

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -134,18 +134,6 @@ class MicrosoftAuthFlow {
     }
   }
 
-  /**
-   * @typedef {Object} JavaTokenOptions
-   * @property {boolean} [fetchEntitlements=false] Whether we should also fetch and return entitlements for this access token.
-   * @property {boolean} [fetchProfile=false] Whether we should also fetch and return profile for this access token.
-   */
-
-  /**
-   * Gets either the cached, or fetchs a new minecraft java token.
-   * @param {JavaTokenOptions} [options = {}] fetchEntitlements, fetchProfile options
-   * @returns {object}
-   */
-
   async getMinecraftJavaToken (options = {}) {
     const response = { token: '', entitlements: {}, profile: {} }
     if (await this.mca.verifyTokens()) {

--- a/src/TokenManagers/XboxTokenManager.js
+++ b/src/TokenManagers/XboxTokenManager.js
@@ -17,7 +17,7 @@ const nextUUID = () => UUID.v3({ namespace: '6ba7b811-9dad-11d1-80b4-00c04fd430c
 // Manages Xbox Live tokens for xboxlive.com
 class XboxTokenManager {
   constructor (ecKey, cacheLocation) {
-    this.relyingParty = null
+    this.relyingParty = Endpoints.XboxXSTSRelyingParty
     this.key = ecKey
     jose.fromKeyLike(ecKey.publicKey).then(jwk => {
       this.jwk = { ...jwk, alg: 'ES256', use: 'sig' }

--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -21,6 +21,11 @@ module.exports = {
       clientId: '389b1b32-b5d5-43b2-bddc-84ce938d6737', // token from https://github.com/microsoft/Office365APIEditor
       authority: 'https://login.microsoftonline.com/consumers'
     }
+  },
+  fetchOptions: {
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': 'node-minecraft-protocol'
+    }
   }
-
 }

--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -2,6 +2,7 @@ module.exports = {
   Endpoints: {
     PCXSTSRelyingParty: 'rp://api.minecraftservices.com/',
     BedrockXSTSRelyingParty: 'https://multiplayer.minecraft.net/',
+    XboxXSTSRelyingParty: 'http://auth.xboxlive.com/',
     BedrockAuth: 'https://multiplayer.minecraft.net/authentication',
     XboxDeviceAuth: 'https://device.auth.xboxlive.com/device/authenticate',
     XboxTitleAuth: 'https://title.auth.xboxlive.com/title/authenticate',


### PR DESCRIPTION
Creates checks for fetchEntitlements, fetchProfile that can be passed in from Authflow options. 

Fixes the relyingParty being null when trying to fetch an xbox token without calling a minecraft token function.

Un-exposes endpoints because its not needed.