### PR TITLE
Improve error handling

### DIFF
--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -15,7 +15,7 @@ const BedrockTokenManager = require('./TokenManagers/MinecraftBedrockTokenManage
 async function retry (methodFn, beforeRetry, times) {
   while (times--) {
     if (times !== 0) {
-      try { return await methodFn() } catch (e) { debug(e) }
+      try { return await methodFn() } catch (e) { if (e instanceof URIError) { throw e } else { debug(e) } }
       await new Promise(resolve => setTimeout(resolve, 2000))
       await beforeRetry()
     } else {

--- a/src/common/Util.js
+++ b/src/common/Util.js
@@ -1,11 +1,12 @@
 const debug = require('debug')('prismarine-auth')
 
-function checkStatus (res) {
+async function checkStatus (res) {
   if (res.ok) { // res.status >= 200 && res.status < 300
     return res.json()
   } else {
-    debug('Request fail', res)
-    throw Error(res.statusText)
+    const resp = await res.json()
+    debug('Request fail', resp)
+    throw Error(`${res.statusText}: ${resp}`)
   }
 }
 


### PR DESCRIPTION
Log some more meaningful errors, try to fail fast when no xbox.com profile is present

Currently, when an error is encountered in one of the steps the code tries to fix it bottom up, which may mean repeatedly asking for sign-in tokens. Eventually after enough tries (2 per step * 2 steps) it gives up and logs an error. _Most_ of the time the errors are temporary (expired/invalidated token) but sometimes the errors cannot be fixed. This PR uses URIError to represent unrecoverable errors.

cc @Kashalls 