### PR TITLE
Add `deviceType` option, fix device code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install prismarine-auth
 - options {Object?}
     - [password] {string} - If passed we will do password based authentication.
     - [authTitle] {string} - See the [API.md](docs/API.md)
+    - [deviceType] {string} - See the [API.md](docs/API.md)
 - onMsaCode {Function} - (For device code auth) What we should do when we get the code. Useful for passing the code to another function.
 
 [View more examples](https://github.com/PrismarineJS/prismarine-auth/tree/master/examples) 
@@ -48,7 +49,7 @@ const { Authflow, Titles } = require('prismarine-auth')
 
 const userIdentifier = 'any unique identifier'
 const cacheDir = './' // You can leave this as undefined unless you want to specify a caching directory
-const options = { authTitle: Titles.MinecraftJava }
+const options = { authTitle: Titles.MinecraftJava, deviceType: 'Win32' }
 const flow = new Authflow(userIdentifier, cacheDir, options)
 // Get a Minecraft Java Edition auth token, then log it
 flow.getMinecraftJavaToken().then(console.log)

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,7 @@ This is the main exposed class you interact with. Every instance holds its own t
 * `options`
   * `password` (optional) If you specify this option, we use password based auth.
   * `authTitle` (optional). See `require('prismarine-auth').Titles` for a list of possible titles, and FAQ section below for more info. Set to `false` if doing password auth.
+  * `deviceType` (optional) if specifying an authTitle, the device type to auth as. For example, `Win32`, `iOS`, `Android`, `Nintendo`
   * `relyingParty` (optional) "relying party", apart of xbox auth api
 * `codeCallback` (optional) The callback to call when doing device code auth. Otherwise, the code will be logged to the console.
 
@@ -45,12 +46,12 @@ The return object are multiple JWTs returned from the auth server, from both the
 
 ### Titles
 
-* A list of known client IDs for convenience. Currently exposes `MinecraftNintendoSwitch` and `MinecraftJava`. These should be passed to `Authflow` options constructor.
+* A list of known client IDs for convenience. Currently exposes `MinecraftNintendoSwitch` and `MinecraftJava`. These should be passed to `Authflow` options constructor (make sure to set appropriate `deviceType`).
 
 Example usage :
 ```js
 const { Authflow, Titles } = require('prismarine-auth')
-const flow = new Authflow('', './', { authTitle: TitlesMinecraftJava })
+const flow = new Authflow('', './', { authTitle: TitlesMinecraftJava, deviceType: 'Nintendo' })
 flow.getMinecraftJavaToken().then(console.log)
 ```
 
@@ -65,3 +66,4 @@ flow.getMinecraftJavaToken().then(console.log)
   * You will get an error if you don't specify it when calling `getMinecraftJavaToken` or `getMinecraftBedrockToken` when doing device code auth. You can set it to `false` to skip signing.
 * If you just want an Microsoft/Xbox token, you do not need to specify a authTitle.
 * If doing password auth, set this option to false.
+* If specifying this, you also should provide a `deviceType`, see the doc above

--- a/docs/API.md
+++ b/docs/API.md
@@ -51,7 +51,7 @@ The return object are multiple JWTs returned from the auth server, from both the
 Example usage :
 ```js
 const { Authflow, Titles } = require('prismarine-auth')
-const flow = new Authflow('', './', { authTitle: TitlesMinecraftJava, deviceType: 'Nintendo' })
+const flow = new Authflow('', './', { authTitle: Titles.MinecraftJava, deviceType: 'Win32' })
 flow.getMinecraftJavaToken().then(console.log)
 ```
 

--- a/examples/bedrock/deviceCode.js
+++ b/examples/bedrock/deviceCode.js
@@ -2,16 +2,18 @@ const { Authflow, Titles } = require('prismarine-auth')
 const crypto = require('crypto')
 const curve = 'secp384r1'
 
-if (process.argv.length !== 4) {
+const [, , username, cacheDir] = process.argv
+
+if (!username) {
   console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
   process.exit(1)
 }
 
 const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64')
 const doAuth = async () => {
-  const flow = new Authflow(process.argv[2], process.argv[3], { authTitle: Titles.MinecraftNintendoSwitch })
+  const flow = new Authflow(username, cacheDir, { authTitle: Titles.MinecraftNintendoSwitch, deviceType: 'Nintendo' })
   const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
   console.log(XSTSToken)
 }
 
-doAuth()
+module.exports = doAuth()

--- a/examples/mcpc/deviceCode.js
+++ b/examples/mcpc/deviceCode.js
@@ -1,14 +1,16 @@
-const { Authflow, Titles } = require('../index')
+const { Authflow, Titles } = require('prismarine-auth')
 
-if (process.argv.length !== 4) {
-  console.log('Usage: node deviceCode.js <username> <cacheDirectory>')
+const [, , username, cacheDir] = process.argv
+
+if (!username) {
+  console.log('Usage: node deviceCode.js <username> [cacheDirectory]')
   process.exit(1)
 }
 
-const doAuth = async () => {
-  const flow = new Authflow(process.argv[2], process.argv[3], { authTitle: Titles.MinecraftJava })
+async function doAuth () {
+  const flow = new Authflow(username, cacheDir, { authTitle: Titles.MinecraftJava, deviceType: 'Win32' })
   const response = await flow.getMinecraftJavaToken({ fetchEntitlements: true, fetchProfile: true })
   console.log(response)
 }
 
-doAuth()
+module.exports = doAuth()

--- a/examples/mcpc/password.js
+++ b/examples/mcpc/password.js
@@ -1,4 +1,4 @@
-const { Authflow } = require('../index')
+const { Authflow } = require('prismarine-auth')
 
 if (process.argv.length !== 5) {
   console.log('Usage: node password.js <username> <password> <cacheDirectory>')
@@ -11,4 +11,4 @@ const doAuth = async () => {
   console.log(response)
 }
 
-doAuth()
+module.exports = doAuth()

--- a/examples/xbox/basic.js
+++ b/examples/xbox/basic.js
@@ -1,3 +1,3 @@
 const { Authflow } = require('prismarine-auth')
 const flow = new Authflow() // No parameters needed
-flow.getXboxToken().then(console.log)
+module.exports = flow.getXboxToken().then(console.log)

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,8 @@ declare module 'prismarine-auth' {
   export interface MicrosoftAuthFlowOptions {
     relyingParty?: RelyingParty
     authTitle?: Titles
+    deviceType?: String
+    deviceVersion?: String
     password?: String
   }
 

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -119,7 +119,7 @@ class MicrosoftAuthFlow {
         const ut = await this.xbl.getUserToken(msaToken, !this.options.authTitle)
 
         if (this.options.authTitle) {
-          const deviceToken = await this.xbl.getDeviceToken({ DeviceType: 'Nintendo', Version: '0.0.0' })
+          const deviceToken = await this.xbl.getDeviceToken(this.options)
           const titleToken = await this.xbl.getTitleToken(msaToken, deviceToken)
           const xsts = await this.xbl.getXSTSToken(ut, deviceToken, titleToken)
           return xsts

--- a/src/TokenManagers/XboxTokenManager.js
+++ b/src/TokenManagers/XboxTokenManager.js
@@ -209,9 +209,9 @@ class XboxTokenManager {
       Properties: {
         AuthMethod: 'ProofOfPossession',
         Id: `{${nextUUID()}}`,
-        DeviceType: asDevice.DeviceType || 'Android',
+        DeviceType: asDevice.deviceType || 'Nintendo',
         SerialNumber: `{${nextUUID()}}`,
-        Version: asDevice.Version || '10',
+        Version: asDevice.deviceVersion || '0.0.0',
         ProofKey: this.jwk
       },
       RelyingParty: 'http://auth.xboxlive.com',

--- a/test/manualCodeTest.js
+++ b/test/manualCodeTest.js
@@ -1,0 +1,18 @@
+// Just importing these will run the code ; any exceptions will crash script
+process.argv = ['', '', 'user@example.com']
+const TESTS = [
+  ['xbox', 'prismarine-auth/examples/xbox/basic'],
+  ['minecraft bedrock edition', 'prismarine-auth/examples/mcpc/deviceCode'],
+  ['minecraft java edition', 'prismarine-auth/examples/mcpc/deviceCode']
+]
+
+console.log('Running device code tests')
+async function main () {
+  for (const [name, file] of TESTS) {
+    console.log('Testing', name, '...')
+    await require(file)
+    console.log('✔️', file)
+  }
+  console.log('✔️ All OK')
+}
+main()


### PR DESCRIPTION
* add a new `deviceType` option to complement `authTitle`, specify an appropriate deviceType for the title
* add new manual test for all the device code auth examples