### PR TITLE
Fix mcpc examples to auth as nintendo switch, fix profile data errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ const { Authflow, Titles } = require('prismarine-auth')
 
 const userIdentifier = 'any unique identifier'
 const cacheDir = './' // You can leave this as undefined unless you want to specify a caching directory
-const options = { authTitle: Titles.MinecraftJava, deviceType: 'Win32' }
-const flow = new Authflow(userIdentifier, cacheDir, options)
+const flow = new Authflow(userIdentifier, cacheDir, { authTitle: false })
 // Get a Minecraft Java Edition auth token, then log it
 flow.getMinecraftJavaToken().then(console.log)
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -35,8 +35,8 @@ flow.getXboxToken().then(console.log)
 #### getMinecraftJavaToken (options?: { fetchEntitlements?: boolean fetchProfile?: boolean }) : Promise<{ token: string, entitlements: object, profile: object }>
 
 Returns a Minecraft Java Edition auth token. 
-* If you specify `fetchEntitlements` optional option, we will check if the account owns Minecraft and return the results of the API call.
-* If you specify `fetchProfile`, we will do a call to `https://api.minecraftservices.com/minecraft/profile` for the currently signed in user and returns the results.
+* If you specify `fetchEntitlements` optional option, we will check if the account owns Minecraft and return the results of the API call. Undefined if request fails.
+* If you specify `fetchProfile`, we will do a call to `https://api.minecraftservices.com/minecraft/profile` for the currently signed in user and returns the results. Undefined if request fails.
 
 ### getMinecraftBedrockToken (publicKey: KeyObject): Promise<string[]>
 
@@ -51,7 +51,7 @@ The return object are multiple JWTs returned from the auth server, from both the
 Example usage :
 ```js
 const { Authflow, Titles } = require('prismarine-auth')
-const flow = new Authflow('', './', { authTitle: Titles.MinecraftJava, deviceType: 'Win32' })
+const flow = new Authflow('', './', { authTitle: Titles.MinecraftNintendoSwitch, deviceType: 'Nintendo' })
 flow.getMinecraftJavaToken().then(console.log)
 ```
 

--- a/examples/mcpc/deviceCode.js
+++ b/examples/mcpc/deviceCode.js
@@ -8,7 +8,7 @@ if (!username) {
 }
 
 async function doAuth () {
-  const flow = new Authflow(username, cacheDir, { authTitle: Titles.MinecraftJava, deviceType: 'Win32' })
+  const flow = new Authflow(username, cacheDir, { authTitle: Titles.MinecraftNintendoSwitch, deviceType: 'Nintendo' })
   const response = await flow.getMinecraftJavaToken({ fetchEntitlements: true, fetchProfile: true })
   console.log(response)
 }

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -148,10 +148,10 @@ class MicrosoftAuthFlow {
     }
 
     if (options.fetchEntitlements) {
-      response.entitlements = await this.mca.fetchEntitlements(response.token)
+      response.entitlements = await this.mca.fetchEntitlements(response.token).catch(e => debug('Failed to obtain entitlement data', e))
     }
     if (options.fetchProfile) {
-      response.profile = await this.mca.fetchProfile(response.token)
+      response.profile = await this.mca.fetchProfile(response.token).catch(e => debug('Failed to obtain profile data', e))
     }
 
     return response


### PR DESCRIPTION
* for mcpc, auth as nintendo switch like bedrock
* return undefined for profile data instead of throwing an exception