### PR TITLE
Allow to use a custom cache instead of using the filesystem only

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install prismarine-auth
 ### Authflow
 **Parameters**
 - username? {String} - Username for authentication
-- cacheDirectory? {String} - Where we will store your tokens (optional)
+- cacheDirectory? {String | Function} - Where we will store your tokens (optional) or a factory function that returns a cache.
 - options {Object?}
     - [password] {string} - If passed we will do password based authentication.
     - [doSisuAuth] {boolean} - See the [API.md](docs/API.md)
@@ -24,7 +24,7 @@ npm install prismarine-auth
     - [deviceType] {string} - See the [API.md](docs/API.md)
 - onMsaCode {Function} - (For device code auth) What we should do when we get the code. Useful for passing the code to another function.
 
-[View more examples](https://github.com/PrismarineJS/prismarine-auth/tree/master/examples) 
+[View more examples](https://github.com/PrismarineJS/prismarine-auth/tree/master/examples)
 
 ### Examples
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,11 +6,11 @@ declare module 'prismarine-auth' {
     /**
      * Creates a new Authflow instance, which holds its own token cache
      * @param username A unique identifier. If using password auth, this should be an email.
-     * @param cache Where to place token cache
+     * @param cache Where to place token cache or a cache factory function.
      * @param options Options
      * @param codeCallback Optional callback to recieve token information using device code auth
      */
-    constructor(username?: string, cache?: string, options?: MicrosoftAuthFlowOptions, codeCallback?: Function)
+    constructor(username?: string, cache?: string | CacheFactory, options?: MicrosoftAuthFlowOptions, codeCallback?: Function)
     /**
      * Deletes the caches in the specified cache directory.
      */
@@ -53,4 +53,12 @@ declare module 'prismarine-auth' {
     BedrockXSTSRelyingParty = 'https://multiplayer.minecraft.net/',
     XboxXSTSRelyingParty = 'http://auth.xboxlive.com/'
   }
+
+  export interface Cache {
+    getCached(): Promise<any>
+    setCached(value: any): Promise<void>
+    setCachedPartial(value: any): Promise<void>
+  }
+
+  export type CacheFactory = (options: { username: string, cacheName: string }) => Cache
 }

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -5,7 +5,7 @@ const assert = require('assert')
 const debug = require('debug')('prismarine-auth')
 
 const { Endpoints, msalConfig } = require('./common/Constants')
-const { FileCache } = require('./common/cache/FileCache')
+const FileCache = require('./common/cache/FileCache')
 
 const LiveTokenManager = require('./TokenManagers/LiveTokenManager')
 const JavaTokenManager = require('./TokenManagers/MinecraftJavaTokenManager')

--- a/src/TokenManagers/MsaTokenManager.js
+++ b/src/TokenManagers/MsaTokenManager.js
@@ -7,8 +7,6 @@ class MsaTokenManager {
     this.scopes = scopes
     this.cache = cache
 
-    // this.reloadCache()
-
     const beforeCacheAccess = async (cacheContext) => {
       cacheContext.tokenCache.deserialize(JSON.stringify(await this.cache.getCached()))
     }

--- a/src/common/cache/FileCache.js
+++ b/src/common/cache/FileCache.js
@@ -36,4 +36,4 @@ class FileCache {
   }
 }
 
-module.exports = { FileCache }
+module.exports = FileCache

--- a/src/common/cache/FileCache.js
+++ b/src/common/cache/FileCache.js
@@ -1,0 +1,39 @@
+const fs = require('fs')
+
+class FileCache {
+  constructor (cacheLocation) {
+    this.cacheLocation = cacheLocation
+  }
+
+  async loadInitialValue () {
+    try {
+      return JSON.parse(fs.readFileSync(this.cacheLocation, 'utf8'))
+    } catch (e) {
+      const cached = {}
+      fs.writeFileSync(this.cacheLocation, JSON.stringify(cached))
+      return cached
+    }
+  }
+
+  async getCached () {
+    if (this.cache === undefined) {
+      this.cache = await this.loadInitialValue()
+    }
+
+    return this.cache
+  }
+
+  async setCached (cached) {
+    this.cache = cached
+    fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
+  }
+
+  async setCachedPartial (cached) {
+    await this.setCached({
+      ...this.cache,
+      ...cached
+    })
+  }
+}
+
+module.exports = { FileCache }

--- a/test/FileCache.js
+++ b/test/FileCache.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha */
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+const FileCache = require('../src/common/cache/FileCache')
+
+describe('file cache', async () => {
+  it('should load and restore data in memory', async () => {
+    const cache = new FileCache('./test-a-cache.json')
+    await cache.setCached({ foo: 'bar' })
+
+    const data = await cache.getCached()
+    expect(data).to.deep.equal({ foo: 'bar' })
+  })
+
+  it('should load and restore data in file', async () => {
+    const cacheSave = new FileCache('./test-b-cache.json')
+    await cacheSave.setCached({ foo: 'bar' })
+
+    const cacheLoad = new FileCache('./test-b-cache.json')
+    const data = await cacheLoad.getCached()
+    expect(data).to.deep.equal({ foo: 'bar' })
+  })
+})


### PR DESCRIPTION
This commit adds the ability to specify a cache factory function instead of a folder
name only when creating an Authflow instance.

The cache factory function will take additional options and must return a cache. A cache
is an class instance that supports basic read and write operations.

The old behavior of the cache has been implemented by a FileCache. The FileCache will be
used as default and works like the old implementation used to.
