### PR TITLE
Move relyingParty option to `getXboxToken`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -15,18 +15,17 @@ This is the main exposed class you interact with. Every instance holds its own t
   * `authTitle` (optional). See `require('prismarine-auth').Titles` for a list of possible titles, and FAQ section below for more info. Set to `false` if doing password auth. Required if doing sisu auth
   * `deviceType` (optional) if specifying an authTitle, the device type to auth as. For example, `Win32`, `iOS`, `Android`, `Nintendo`
   * `doSisuAuth` (optional) If you specify this option, we use sisu based auth.
-  * `relyingParty` (optional) "relying party", apart of xbox auth api
 * `codeCallback` (optional) The callback to call when doing device code auth. Otherwise, the code will be logged to the console.
 
 #### getMsaToken () : Promise<string>
 
 [Returns a Microsoft account access token.](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens)
 
-#### getXboxToken () : Promise<{ userXUID: string, userHash: string, XSTSToken: string, expiresOn: number }>
+#### getXboxToken (relyingParty?: string) : Promise<{ userXUID: string, userHash: string, XSTSToken: string, expiresOn: number }>
 
 [Returns XSTS token data](https://docs.microsoft.com/en-us/gaming/xbox-live/api-ref/xbox-live-rest/additional/edsauthorization).
 
-* Define `doSisuAuth` as true if you're trying to generate an xsts token using an authTitle such as XboxAppIOS, XboxGamepassIOS or MinecraftJava
+* `relyingParty` (optional, default='http://xboxlive.com') "relying party", apart of xbox auth api
 
 Example usage :
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare module 'prismarine-auth' {
     // Returns a Microsoft Oauth access token -- https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
     getMsaToken(): Promise<string>
     // Returns an XSTS token -- https://docs.microsoft.com/en-us/gaming/xbox-live/api-ref/xbox-live-rest/additional/edsauthorization
-    getXboxToken(): Promise<{
+    getXboxToken(relyingParty?: string): Promise<{
       userXUID: string,
       userHash: string,
       XSTSToken: string,
@@ -35,7 +35,6 @@ declare module 'prismarine-auth' {
   }
 
   export interface MicrosoftAuthFlowOptions {
-    relyingParty?: RelyingParty
     authTitle?: Titles
     deviceType?: String
     deviceVersion?: String
@@ -51,7 +50,8 @@ declare module 'prismarine-auth' {
   export enum RelyingParty {
     PCXSTSRelyingParty = 'rp://api.minecraftservices.com/',
     BedrockXSTSRelyingParty = 'https://multiplayer.minecraft.net/',
-    XboxXSTSRelyingParty = 'http://auth.xboxlive.com/'
+    XboxAuthRelyingParty = 'http://auth.xboxlive.com/',
+    XboxRelyingParty = 'http://xboxlive.com'
   }
 
   export interface Cache {

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -152,10 +152,9 @@ class MicrosoftAuthFlow {
       const { token } = await this.mca.getCachedAccessToken()
       response.token = token
     } else {
-      this.xbl.relyingParty = Endpoints.PCXSTSRelyingParty
       debug('[mc] Need to obtain tokens')
       await retry(async () => {
-        const xsts = await this.getXboxToken()
+        const xsts = await this.getXboxToken(Endpoints.PCXSTSRelyingParty)
         debug('[xbl] xsts data', xsts)
         response.token = await this.mca.getAccessToken(xsts)
       }, () => { this.xbl.forceRefresh = true }, 2)
@@ -181,10 +180,9 @@ class MicrosoftAuthFlow {
       return chain
     } else {
       if (!publicKey) throw new Error('Need to specifiy a ECDH x509 URL encoded public key')
-      this.xbl.relyingParty = Endpoints.BedrockXSTSRelyingParty
       debug('[mc] Need to obtain tokens')
       return await retry(async () => {
-        const xsts = await this.getXboxToken()
+        const xsts = await this.getXboxToken(Endpoints.BedrockXSTSRelyingParty)
         debug('[xbl] xsts data', xsts)
         const token = await this.mba.getAccessToken(publicKey, xsts)
         // If we want to auth with a title ID, make sure there's a TitleID in the response

--- a/src/TokenManagers/MsaTokenManager.js
+++ b/src/TokenManagers/MsaTokenManager.js
@@ -76,7 +76,6 @@ class MsaTokenManager {
     return new Promise((resolve, reject) => {
       this.msalApp.acquireTokenByRefreshToken(refreshTokenRequest).then((response) => {
         debug('[msa] refreshed token', JSON.stringify(response))
-        this.reloadCache()
         resolve(response)
       }).catch((error) => {
         debug('[msa] failed to refresh', JSON.stringify(error))

--- a/src/TokenManagers/XboxTokenManager.js
+++ b/src/TokenManagers/XboxTokenManager.js
@@ -7,7 +7,7 @@ const { exportJWK } = require('jose')
 const fetch = require('node-fetch')
 
 const { Endpoints } = require('../common/Constants')
-const { checkStatus } = require('../common/Util')
+const { checkStatus, createHash } = require('../common/Util')
 
 const UUID = require('uuid-1345')
 const nextUUID = () => UUID.v3({ namespace: '6ba7b811-9dad-11d1-80b4-00c04fd430c8', name: Date.now().toString() })
@@ -15,7 +15,6 @@ const nextUUID = () => UUID.v3({ namespace: '6ba7b811-9dad-11d1-80b4-00c04fd430c
 // Manages Xbox Live tokens for xboxlive.com
 class XboxTokenManager {
   constructor (ecKey, cache) {
-    this.relyingParty = Endpoints.XboxXSTSRelyingParty
     this.key = ecKey
     exportJWK(ecKey.publicKey).then(jwk => {
       this.jwk = { ...jwk, alg: 'ES256', use: 'sig' }
@@ -35,8 +34,9 @@ class XboxTokenManager {
     return { valid, token: token.Token, data: token }
   }
 
-  async getCachedXstsToken () {
-    const { xstsToken: token } = await this.cache.getCached()
+  async getCachedXstsToken (relyingParty) {
+    const key = createHash(relyingParty)
+    const { [key]: token } = await this.cache.getCached()
     if (!token) return
     const until = new Date(token.expiresOn)
     const dn = Date.now()
@@ -49,8 +49,9 @@ class XboxTokenManager {
     await this.cache.setCachedPartial({ userToken: data })
   }
 
-  async setCachedXstsToken (data) {
-    await this.cache.setCachedPartial({ xstsToken: data })
+  async setCachedXstsToken (data, relyingParty) {
+    const key = createHash(relyingParty)
+    await this.cache.setCachedPartial({ [key]: data })
   }
 
   checkTokenError (errorCode, response) {
@@ -66,9 +67,9 @@ class XboxTokenManager {
     }
   }
 
-  async verifyTokens () {
+  async verifyTokens (relyingParty) {
     const ut = await this.getCachedUserToken()
-    const xt = await this.getCachedXstsToken()
+    const xt = await this.getCachedXstsToken(relyingParty)
     if (!ut || !xt || this.forceRefresh) {
       return false
     }
@@ -77,7 +78,7 @@ class XboxTokenManager {
       return true
     } else if (ut.valid && !xt.valid) {
       try {
-        await this.getXSTSToken(ut.data)
+        await this.getXSTSToken(ut.data, null, null, { relyingParty })
         return true
       } catch (e) {
         return false
@@ -126,14 +127,14 @@ class XboxTokenManager {
     return header.toBuffer()
   }
 
-  async doReplayAuth (email, password) {
+  async doReplayAuth (email, password, options = {}) {
     try {
       const preAuthResponse = await XboxLiveAuth.preAuth()
       const logUserResponse = await XboxLiveAuth.logUser(preAuthResponse, { email, password })
       const xblUserToken = await XboxLiveAuth.exchangeRpsTicketForUserToken(logUserResponse.access_token)
       await this.setCachedUserToken(xblUserToken)
       debug('[xbl] user token:', xblUserToken)
-      const xsts = await this.getXSTSToken(xblUserToken)
+      const xsts = await this.getXSTSToken(xblUserToken, null, null, options)
       return xsts
     } catch (error) {
       debug('Authentication using a password has failed.')
@@ -142,7 +143,7 @@ class XboxTokenManager {
     }
   }
 
-  async doSisuAuth (accessToken, deviceToken, options) {
+  async doSisuAuth (accessToken, deviceToken, options = {}) {
     const payload = {
       AccessToken: 't=' + accessToken,
       AppId: options.authTitle,
@@ -150,7 +151,7 @@ class XboxTokenManager {
       Sandbox: 'RETAIL',
       UseModernGamertag: true,
       SiteName: 'user.auth.xboxlive.com',
-      RelyingParty: options.relyingParty || 'http://xboxlive.com',
+      RelyingParty: options.relyingParty,
       ProofKey: this.jwk
     }
 
@@ -172,7 +173,7 @@ class XboxTokenManager {
       expiresOn: ret.AuthorizationToken.NotAfter
     }
 
-    await this.setCachedXstsToken(xsts)
+    await this.setCachedXstsToken(xsts, options.relyingParty)
     debug('[xbl] xsts', xsts)
     return xsts
   }
@@ -180,29 +181,29 @@ class XboxTokenManager {
   // If we don't need Xbox Title Authentication, we can have xboxreplay lib
   // handle the auth, otherwise we need to build the request ourselves with
   // the extra token data.
-  async getXSTSToken (xblUserToken, deviceToken, titleToken) {
+  async getXSTSToken (xblUserToken, deviceToken, titleToken, options = {}) {
     if (deviceToken && titleToken) return this.getXSTSTokenWithTitle(xblUserToken, deviceToken, titleToken)
 
     debug('[xbl] obtaining xsts token with xbox user token (with XboxReplay)', xblUserToken.Token)
-    debug(this.relyingParty)
-    const xsts = await XboxLiveAuth.exchangeUserTokenForXSTSIdentity(xblUserToken.Token, { XSTSRelyingParty: this.relyingParty, raw: false })
-    await this.setCachedXstsToken(xsts)
+    debug(options.relyingParty)
+    const xsts = await XboxLiveAuth.exchangeUserTokenForXSTSIdentity(xblUserToken.Token, { XSTSRelyingParty: options.relyingParty, raw: false })
+    await this.setCachedXstsToken(xsts, options.relyingParty)
     debug('[xbl] xsts', xsts)
     return xsts
   }
 
-  async getXSTSTokenWithTitle (xblUserToken, deviceToken, titleToken, optionalDisplayClaims) {
+  async getXSTSTokenWithTitle (xblUserToken, deviceToken, titleToken, options = {}) {
     const userToken = xblUserToken.Token
     debug('[xbl] obtaining xsts token with xbox user token', userToken)
 
     const payload = {
-      RelyingParty: this.relyingParty,
+      RelyingParty: options.relyingParty,
       TokenType: 'JWT',
       Properties: {
         UserTokens: [userToken],
         DeviceToken: deviceToken,
         TitleToken: titleToken,
-        OptionalDisplayClaims: optionalDisplayClaims,
+        OptionalDisplayClaims: options.optionalDisplayClaims,
         ProofKey: this.jwk,
         SandboxId: 'RETAIL'
       }
@@ -224,7 +225,7 @@ class XboxTokenManager {
       expiresOn: ret.NotAfter
     }
 
-    await this.setCachedXstsToken(xsts)
+    await this.setCachedXstsToken(xsts, options.relyingParty)
     debug('[xbl] xsts', xsts)
     return xsts
   }

--- a/src/TokenManagers/XboxTokenManager.js
+++ b/src/TokenManagers/XboxTokenManager.js
@@ -182,7 +182,7 @@ class XboxTokenManager {
   // handle the auth, otherwise we need to build the request ourselves with
   // the extra token data.
   async getXSTSToken (xblUserToken, deviceToken, titleToken, options = {}) {
-    if (deviceToken && titleToken) return this.getXSTSTokenWithTitle(xblUserToken, deviceToken, titleToken)
+    if (deviceToken && titleToken) return this.getXSTSTokenWithTitle(xblUserToken, deviceToken, titleToken, options)
 
     debug('[xbl] obtaining xsts token with xbox user token (with XboxReplay)', xblUserToken.Token)
     debug(options.relyingParty)

--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -2,7 +2,8 @@ module.exports = {
   Endpoints: {
     PCXSTSRelyingParty: 'rp://api.minecraftservices.com/',
     BedrockXSTSRelyingParty: 'https://multiplayer.minecraft.net/',
-    XboxXSTSRelyingParty: 'http://auth.xboxlive.com/',
+    XboxAuthRelyingParty: 'http://auth.xboxlive.com/',
+    XboxRelyingParty: 'http://xboxlive.com',
     BedrockAuth: 'https://multiplayer.minecraft.net/authentication',
     XboxDeviceAuth: 'https://device.auth.xboxlive.com/device/authenticate',
     XboxTitleAuth: 'https://title.auth.xboxlive.com/title/authenticate',

--- a/src/common/Util.js
+++ b/src/common/Util.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('prismarine-auth')
+const crypto = require('crypto')
 
 async function checkStatus (res) {
   if (res.ok) { // res.status >= 200 && res.status < 300
@@ -10,4 +11,8 @@ async function checkStatus (res) {
   }
 }
 
-module.exports = { checkStatus }
+function createHash (input) {
+  return crypto.createHash('sha1').update(input ?? '', 'binary').digest('hex').substr(0, 6)
+}
+
+module.exports = { checkStatus, createHash }


### PR DESCRIPTION
Moving this option to the `getXboxToken` function allows a single instance to create multiple xsts tokens using different relying-parties as well as caching them for future use. The XSAPI has a handful of endpoints only accessible with certain relying-parties and the current implementation doesn't allow for fluid retrieval of correct tokens as the relying-party is a static option defined in the authflow constructor. 

To prevent this being a breaking change the relying party defined in existing constructors will still be used should no relying-party be passed to `getXboxToken`