### PR TITLE
Let devs log the code callback if they want & Some typings for Device Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm install prismarine-auth
     - [authTitle] {string} - See the [API.md](docs/API.md)
     - [deviceType] {string} - See the [API.md](docs/API.md)
 - onMsaCode {Function} - (For device code auth) What we should do when we get the code. Useful for passing the code to another function.
+- onAuthenticated - (For MSA) Is called before when the getMSAToken has finished.
 
 [View more examples](https://github.com/PrismarineJS/prismarine-auth/tree/master/examples)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install prismarine-auth
     - [authTitle] {string} - See the [API.md](docs/API.md)
     - [deviceType] {string} - See the [API.md](docs/API.md)
 - onMsaCode {Function} - (For device code auth) What we should do when we get the code. Useful for passing the code to another function.
-- onAuthenticated - (For MSA) Is called before when the getMSAToken has finished.
+- onAuthenticated {Function} - (For MSA) Is called before when the getMSAToken has finished.
 
 [View more examples](https://github.com/PrismarineJS/prismarine-auth/tree/master/examples)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ npm install prismarine-auth
     - [authTitle] {string} - See the [API.md](docs/API.md)
     - [deviceType] {string} - See the [API.md](docs/API.md)
 - onMsaCode {Function} - (For device code auth) What we should do when we get the code. Useful for passing the code to another function.
-- onAuthenticated {Function} - (For MSA) Is called before when the getMSAToken has finished.
 
 [View more examples](https://github.com/PrismarineJS/prismarine-auth/tree/master/examples)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare module 'prismarine-auth' {
      * @param options Options
      * @param codeCallback Optional callback to recieve token information using device code auth
      */
-    constructor(username?: string, cache?: string | CacheFactory, options?: MicrosoftAuthFlowOptions, codeCallback?: Function)
+    constructor(username?: string, cache?: string | CacheFactory, options?: MicrosoftAuthFlowOptions, codeCallback?: (res: { userCode: string, deviceCode: string, verificationUri:  string, expiresIn: number, interval: number, message: string }) => void, authCallback?: Function)
     /**
      * Deletes the caches in the specified cache directory.
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare module 'prismarine-auth' {
      * @param options Options
      * @param codeCallback Optional callback to recieve token information using device code auth
      */
-    constructor(username?: string, cache?: string | CacheFactory, options?: MicrosoftAuthFlowOptions, codeCallback?: (res: { userCode: string, deviceCode: string, verificationUri:  string, expiresIn: number, interval: number, message: string }) => void, authCallback?: Function)
+    constructor(username?: string, cache?: string | CacheFactory, options?: MicrosoftAuthFlowOptions, codeCallback?: (res: { userCode: string, deviceCode: string, verificationUri:  string, expiresIn: number, interval: number, message: string }) => void)
     /**
      * Deletes the caches in the specified cache directory.
      */

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -27,12 +27,11 @@ async function retry (methodFn, beforeRetry, times) {
 }
 
 class MicrosoftAuthFlow {
-  constructor (username = '', cache = __dirname, options = {}, codeCallback, authCallback) {
+  constructor (username = '', cache = __dirname, options = {}, codeCallback) {
     this.username = username
     this.options = options
     this.initTokenManagers(username, cache)
     this.codeCallback = codeCallback
-    this.authCallback = authCallback
   }
 
   initTokenManagers (username, cache) {
@@ -102,7 +101,6 @@ class MicrosoftAuthFlow {
         console.info('[msa] Signed in with Microsoft')
       }
 
-      this.authCallback(ret)
       debug('[msa] got auth result', ret)
       return ret.accessToken
     }

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -27,11 +27,12 @@ async function retry (methodFn, beforeRetry, times) {
 }
 
 class MicrosoftAuthFlow {
-  constructor (username = '', cache = __dirname, options = {}, codeCallback) {
+  constructor (username = '', cache = __dirname, options = {}, codeCallback, authCallback) {
     this.username = username
     this.options = options
     this.initTokenManagers(username, cache)
     this.codeCallback = codeCallback
+    this.authCallback = authCallback
   }
 
   initTokenManagers (username, cache) {
@@ -90,9 +91,9 @@ class MicrosoftAuthFlow {
     } else {
       debug('[msa] No valid cached tokens, need to sign in')
       const ret = await this.msa.authDeviceCode((response) => {
+        if (this.codeCallback) return this.codeCallback(response)
         console.info('[msa] First time signing in. Please authenticate now:')
         console.info(response.message)
-        if (this.codeCallback) this.codeCallback(response)
       })
 
       if (ret.account) {
@@ -101,6 +102,7 @@ class MicrosoftAuthFlow {
         console.info('[msa] Signed in with Microsoft')
       }
 
+      this.authCallback(ret)
       debug('[msa] got auth result', ret)
       return ret.accessToken
     }


### PR DESCRIPTION
-Type for code callback, probably should make a type at the bottom or something instead of a object shoved up there but it will work
~- Added authCallback, I plan on using this for bedrock-protocol later because as I recall there isn't an existing method to detect when they've logged in just the codeCallback and I need to know after they sign-in for a project.~
-Returns when there is a codeCallback before it logs to console, if people need it logged and need codeCallback at the same time they can log it to console themselves.