### PR TITLE
Release 2.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 ## History
 
+### 2.0.0
+* BREAKING : Add flow option (#55) @LucienHH
+  * `flow` argument now required to explicitly specify what authentication flow (alternative endpoints for authentication) to use when instantiating Authflow. Supported options are `live`, `msal`, `sisu` ; see documentation for more information. Set this to `msal` if you have an custom Azure client token or `live` if you want to login as a official Microsoft app (like vanilla Minecraft client). 
+
 ### 1.7.0
 * Breaking: Abstract fetchCertificates in MinecraftJavaTokenManager (#52) 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismarine-auth",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "Authentication library for Microsoft, Xbox Live, and Minecraft with caching support",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
node-minecraft-protocol and bedrock-protocol need to be updated for this, by adding `flow: 'live'` argument when creating a new `Authflow` instance