### PR TITLE
Change String to string in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,38 +37,38 @@ declare module 'prismarine-auth' {
 
   export interface MinecraftJavaEntitlements {
     items: MinecraftJavaEntitlementsItem[]
-    signature: String
-    keyId: String
+    signature: string
+    keyId: string
   }
 
   export interface MinecraftJavaEntitlementsItem {
-    name: String
-    signature: String
+    name: string
+    signature: string
   }
 
   export interface MinecraftJavaProfile {
-    id: String
-    name: String
+    id: string
+    name: string
     skins: MinecraftJavaProfileSkin[]
     capes: Array
   }
 
   export interface MinecraftJavaProfileSkin {
-    id: String,
-    state: String,
-    url: String,
+    id: string,
+    state: string,
+    url: string,
     variant: 'CLASSIC'|'SLIM'
   }
 
   export interface MinecraftJavaCertificatesRaw {
     keyPair: {
-      privateKey: String
-      publicKey: String
+      privateKey: string
+      publicKey: string
     }
-    publicKeySignature: String
-    publicKeySignatureV2: String
-    expiresAt: String
-    refreshedAfter: String
+    publicKeySignature: string
+    publicKeySignatureV2: string
+    expiresAt: string
+    refreshedAfter: string
   }
 
   export interface MinecraftJavaCertificates {
@@ -76,21 +76,21 @@ declare module 'prismarine-auth' {
       public: KeyObject
       private: KeyObject
       // PEM encoded keys from server
-      publicPEM: String
-      privatePEM: String
+      publicPEM: string
+      privatePEM: string
       // DER transformed keys
-      publicDER: String,
-      privateDER: String
+      publicDER: string,
+      privateDER: string
     },
-    expiresOn: String
-    refreshAfter: String
+    expiresOn: string
+    refreshAfter: string
   }
 
   export interface MicrosoftAuthFlowOptions {
     authTitle?: Titles
-    deviceType?: String
-    deviceVersion?: String
-    password?: String
+    deviceType?: string
+    deviceVersion?: string
+    password?: string
     flow: 'live' | 'msal' | 'sisu'
   }
 


### PR DESCRIPTION
There is no benefit to use `String` over its primitive `string`, and it's largely considered bad practice to use `String` over `string`.

Currently [data from prismarine-auth](https://github.com/PrismarineJS/prismarine-auth/blob/bca4a9238414d25f08de21bc656b8b9d1bddce7a/index.d.ts#L51) cannot be assigned to [node-minecraft-protocol's session option](https://github.com/PrismarineJS/node-minecraft-protocol/blob/master/src/index.d.ts#L99) despite session being directly passed back to prismarine-auth due to type inconsistencies.

The names of the properties seem to be different between prismarine-auth and nmp, however that can be addressed in another PR.