### PR TITLE
Fix Typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,26 +37,26 @@ declare module 'prismarine-auth' {
 
   export interface MinecraftJavaEntitlements {
     items: MinecraftJavaEntitlementsItem[]
-    signature: string
-    keyId: string
+    signature: String
+    keyId: String
   }
 
   export interface MinecraftJavaEntitlementsItem {
-    name: string
-    signature: string
+    name: String
+    signature: String
   }
 
   export interface MinecraftJavaProfile {
-    id: string
-    name: string
+    id: String
+    name: String
     skins: MinecraftJavaProfileSkin[]
     capes: MinecraftJavaProfileCape[]
   }
 
   export interface MinecraftJavaProfileSkin {
-    id: string,
-    state: string,
-    url: string,
+    id: String,
+    state: String,
+    url: String,
     variant: 'CLASSIC'|'SLIM'
   }
 
@@ -69,13 +69,13 @@ declare module 'prismarine-auth' {
 
   export interface MinecraftJavaCertificatesRaw {
     keyPair: {
-      privateKey: string
-      publicKey: string
+      privateKey: String
+      publicKey: String
     }
-    publicKeySignature: string
-    publicKeySignatureV2: string
-    expiresAt: string
-    refreshedAfter: string
+    publicKeySignature: String
+    publicKeySignatureV2: String
+    expiresAt: String
+    refreshedAfter: String
   }
 
   export interface MinecraftJavaCertificates {
@@ -83,21 +83,21 @@ declare module 'prismarine-auth' {
       public: KeyObject
       private: KeyObject
       // PEM encoded keys from server
-      publicPEM: string
-      privatePEM: string
+      publicPEM: String
+      privatePEM: String
       // DER transformed keys
-      publicDER: string,
-      privateDER: string
+      publicDER: String,
+      privateDER: String
     },
-    expiresOn: string
-    refreshAfter: string
+    expiresOn: String
+    refreshAfter: String
   }
 
   export interface MicrosoftAuthFlowOptions {
     authTitle?: Titles
-    deviceType?: string
-    deviceVersion?: string
-    password?: string
+    deviceType?: String
+    deviceVersion?: String
+    password?: String
     flow: 'live' | 'msal' | 'sisu'
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,38 +37,45 @@ declare module 'prismarine-auth' {
 
   export interface MinecraftJavaEntitlements {
     items: MinecraftJavaEntitlementsItem[]
-    signature: String
-    keyId: String
+    signature: string
+    keyId: string
   }
 
   export interface MinecraftJavaEntitlementsItem {
-    name: String
-    signature: String
+    name: string
+    signature: string
   }
 
   export interface MinecraftJavaProfile {
-    id: String
-    name: String
+    id: string
+    name: string
     skins: MinecraftJavaProfileSkin[]
-    capes: Array
+    capes: MinecraftJavaProfileCape[]
   }
 
   export interface MinecraftJavaProfileSkin {
-    id: String,
-    state: String,
-    url: String,
+    id: string,
+    state: string,
+    url: string,
     variant: 'CLASSIC'|'SLIM'
+  }
+
+  export interface MinecraftJavaProfileCape {
+    id: string,
+    state: string,
+    url: string,
+    alias: string
   }
 
   export interface MinecraftJavaCertificatesRaw {
     keyPair: {
-      privateKey: String
-      publicKey: String
+      privateKey: string
+      publicKey: string
     }
-    publicKeySignature: String
-    publicKeySignatureV2: String
-    expiresAt: String
-    refreshedAfter: String
+    publicKeySignature: string
+    publicKeySignatureV2: string
+    expiresAt: string
+    refreshedAfter: string
   }
 
   export interface MinecraftJavaCertificates {
@@ -76,21 +83,21 @@ declare module 'prismarine-auth' {
       public: KeyObject
       private: KeyObject
       // PEM encoded keys from server
-      publicPEM: String
-      privatePEM: String
+      publicPEM: string
+      privatePEM: string
       // DER transformed keys
-      publicDER: String,
-      privateDER: String
+      publicDER: string,
+      privateDER: string
     },
-    expiresOn: String
-    refreshAfter: String
+    expiresOn: string
+    refreshAfter: string
   }
 
   export interface MicrosoftAuthFlowOptions {
     authTitle?: Titles
-    deviceType?: String
-    deviceVersion?: String
-    password?: String
+    deviceType?: string
+    deviceVersion?: string
+    password?: string
     flow: 'live' | 'msal' | 'sisu'
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare module 'prismarine-auth' {
      * @param options Options
      * @param codeCallback Optional callback to recieve token information using device code auth
      */
-    constructor(username?: string, cache?: string | CacheFactory, options?: MicrosoftAuthFlowOptions, codeCallback?: (res: { userCode: string, deviceCode: string, verificationUri:  string, expiresIn: number, interval: number, message: string }) => void)
+    constructor(username?: string, cache?: string | CacheFactory, options?: MicrosoftAuthFlowOptions, codeCallback?: (res: ServerDeviceCodeResponse) => void)
     /**
      * Deletes the caches in the specified cache directory.
      */
@@ -111,6 +111,15 @@ declare module 'prismarine-auth' {
     BedrockXSTSRelyingParty = 'https://multiplayer.minecraft.net/',
     XboxAuthRelyingParty = 'http://auth.xboxlive.com/',
     XboxRelyingParty = 'http://xboxlive.com'
+  }
+
+  type ServerDeviceCodeResponse = {
+      user_code: string
+      device_code: string
+      verification_uri: string
+      expires_in: number
+      interval: number
+      message: string
   }
 
   export interface Cache {


### PR DESCRIPTION
This fixes three things with the type definitions:

- Use of plain "Array" type for capes property of profiles. (This made any typescript project not compile)
  - To fix this, I created an interface for capes.
- Added a ServerDeviceCodeResponse, taken from msal-common. This fixes typing for code callbacks.
- Switched all instances of `String` to `string`. This is recommended by Typescript, and half of the file was already using `string`.