### PR TITLE
Add mcpc chat report method

### DIFF
--- a/src/TokenManagers/MinecraftJavaTokenManager.js
+++ b/src/TokenManagers/MinecraftJavaTokenManager.js
@@ -147,7 +147,7 @@ class MinecraftJavaTokenManager {
               hashOfBody: e.hash,
               signature: e.signature
             },
-            body: {
+            body: e.timestamp ? {
               timestamp: e.timestamp,
               salt: e.salt,
               lastSeenSignatures: e.lastSeen.map(m => ({
@@ -155,8 +155,7 @@ class MinecraftJavaTokenManager {
                 lastSignature: m.signature
               })),
               message: e.message
-            },
-            overridenMessage: e.originalMessage // if it was modified by the server, ChatTrustLevel.java
+            } : null
           }
         }),
         reportedEntity: {

--- a/src/TokenManagers/MinecraftJavaTokenManager.js
+++ b/src/TokenManagers/MinecraftJavaTokenManager.js
@@ -5,6 +5,27 @@ const crypto = require('crypto')
 const { Endpoints, fetchOptions } = require('../common/Constants')
 const { checkStatus } = require('../common/Util')
 
+const reportLimits = {
+  maxOpinionCommentsLength: 1000,
+  maxReportedMessageCount: 4,
+  maxEvidenceMessageCount: 40,
+  leadingContextMessageCount: 9,
+  trailingContextMessageCount: 0
+}
+
+const reportReasons = {
+  FALSE_REPORTING: 2,
+  HATE_SPEECH: 5,
+  TERRORISM_OR_VIOLENT_EXTREMISM: 16,
+  CHILD_SEXUAL_EXPLOITATION_OR_ABUSE: 17,
+  IMMINENT_HARM: 18,
+  NON_CONSENSUAL_INTIMATE_IMAGERY: 19,
+  HARASSMENT_OR_BULLYING: 21,
+  DEFAMATION_IMPERSONATION_FALSE_INFORMATION: 27,
+  SELF_HARM_OR_SUICIDE: 31,
+  ALCOHOL_TOBACCO_DRUGS: 39
+}
+
 const toDER = pem => pem.split('\n').slice(1, -1).reduce((acc, cur) => Buffer.concat([acc, Buffer.from(cur, 'base64')]), Buffer.alloc(0))
 
 class MinecraftJavaTokenManager {
@@ -96,6 +117,59 @@ class MinecraftJavaTokenManager {
     profileKeys.public = crypto.createPublicKey({ key: profileKeys.publicDER, format: 'der', type: 'spki' })
     profileKeys.private = crypto.createPrivateKey({ key: profileKeys.privateDER, format: 'der', type: 'pkcs8' })
     return { profileKeys }
+  }
+
+  async reportPlayerChat (report) {
+    const accessToken = await this.getCachedAccessToken()
+    const headers = { ...fetchOptions.headers, Authorization: `Bearer ${accessToken}` }
+    const createdTime = report.time || Date.now()
+    const id = report.id || Date.now()
+    const reportedMessagesCount = report.message.reduce((acc, cur) => { acc += (cur.reported ? 1 : 0); return acc }, 0)
+
+    // Some basic client-side sanity checks to replicate vanilla behavior as server does not explain errors
+    if (report.comments > reportLimits.maxOpinionCommentsLength) throw Error(`Report comment is too long, max allowed length is ${reportLimits.maxOpinionCommentsLength}`)
+    if (!report.messages.length) throw Error('No messages were provided as evidence for report')
+    if (report.messages.length > reportLimits.report.maxEvidenceMessageCount) throw Error(`Too many messages provided as evidence, max allowed is ${reportLimits.maxEvidenceMessageCount}`)
+    if (reportedMessagesCount > reportLimits.maxReportedMessageCount) throw Error(`Too many reported messages, max allowed is ${reportLimits.maxReportedMessageCount}`)
+    if (!report.reason) throw Error('Report reason was not specified')
+    if (!(report.reason in reportReasons)) throw Error(`Invalid report reason: ${report.reason}`)
+
+    const body = {
+      id,
+      report: {
+        reason: report.reason,
+        opinionComments: report.comments,
+        evidence: report.messages.map(e => {
+          return {
+            header: {
+              signatureOfPreviousHeader: e.previousHeaderSignature,
+              profileId: e.uuid,
+              hashOfBody: e.hash,
+              signature: e.signature
+            },
+            body: {
+              timestamp: e.timestamp,
+              salt: e.salt,
+              lastSeenSignatures: e.lastSeen.map(m => ({
+                profileId: m.uuid,
+                lastSignature: m.signature
+              })),
+              message: e.message
+            },
+            overridenMessage: e.originalMessage // if it was modified by the server, ChatTrustLevel.java
+          }
+        }),
+        reportedEntity: {
+          profileId: report.reportedPlayer
+        },
+        createdTime
+      }
+    }
+
+    debug('[mc] reporting player with payload', body)
+    const reportResponse = await fetch(Endpoints.MinecraftServicesReport, { method: 'post', headers, body }).then(checkStatus)
+    debug('[mc] server response for report', reportResponse)
+    return true
   }
 }
 module.exports = MinecraftJavaTokenManager

--- a/src/TokenManagers/MinecraftJavaTokenManager.js
+++ b/src/TokenManagers/MinecraftJavaTokenManager.js
@@ -155,14 +155,23 @@ class MinecraftJavaTokenManager {
                 lastSignature: m.signature
               })),
               message: e.message
-            } : null
+            } : null,
+            overridenMessage: e.originalMessage, // if it was modified by the server, ChatTrustLevel.java
+            messageReported: e.reported
           }
         }),
         reportedEntity: {
           profileId: report.reportedPlayer
         },
         createdTime
-      }
+      },
+      clientInfo: {
+        clientVersion: report.clientVersion
+      },
+      thirdPartyServerInfo: {
+        address: report.serverAddress
+      },
+      realmInfo: report.realmInfo
     }
 
     debug('[mc] reporting player with payload', body)

--- a/src/TokenManagers/MinecraftJavaTokenManager.js
+++ b/src/TokenManagers/MinecraftJavaTokenManager.js
@@ -147,15 +147,17 @@ class MinecraftJavaTokenManager {
               hashOfBody: e.hash,
               signature: e.signature
             },
-            body: e.timestamp ? {
-              timestamp: e.timestamp,
-              salt: e.salt,
-              lastSeenSignatures: e.lastSeen.map(m => ({
-                profileId: m.uuid,
-                lastSignature: m.signature
-              })),
-              message: e.message
-            } : null,
+            body: e.timestamp
+              ? {
+                  timestamp: e.timestamp,
+                  salt: e.salt,
+                  lastSeenSignatures: e.lastSeen.map(m => ({
+                    profileId: m.uuid,
+                    lastSignature: m.signature
+                  })),
+                  message: e.message
+                }
+              : null,
             overridenMessage: e.originalMessage, // if it was modified by the server, ChatTrustLevel.java
             messageReported: e.reported
           }

--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -14,6 +14,7 @@ module.exports = {
     MinecraftServicesCertificate: 'https://api.minecraftservices.com/player/certificates',
     MinecraftServicesEntitlement: 'https://api.minecraftservices.com/entitlements/mcstore',
     MinecraftServicesProfile: 'https://api.minecraftservices.com/minecraft/profile',
+    MinecraftServicesReport: 'https://api.minecraftservices.com/player/report',
     LiveDeviceCodeRequest: 'https://login.live.com/oauth20_connect.srf',
     LiveTokenRequest: 'https://login.live.com/oauth20_token.srf'
   },


### PR DESCRIPTION
prismarine-auth doesn't seem like the right place with this API but having access to the cached access tokens / auth data makes it easier to implement here