### PR TITLE
Implement password method

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -113,6 +113,13 @@ function cacheFactory ({ username, cacheName }) {
 
 ## FAQ
 
+### Why is password auth unreliable ?
+* The implementation of password auth is a hacky workaround reversed engineered from the login flow when an account logs in on an Xbox console. The process mimics logging in on a browser and is very likely to be blocked by one of the following:
+  * If an account has never signed into the application/authTitle before. This is due to the account needing to accept the application's scope permissions.
+  * If an account has 2FA enabled. We do not recommend disabling 2FA for this, please use device code auth instead.
+  * If an account is logging in from an unusual location. Verify login from new location at https://account.live.com/activity
+  * Invalid credentials. Make sure you are using the correct email, defined as the `username` parameter in the constructor and the correct password.
+
 ### What does "authTitle" do ?
 
 * The auth title is the "Client ID" used for authenticating to Microsoft. [This is apart of Oauth.](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow)
@@ -121,7 +128,6 @@ function cacheFactory ({ username, cacheName }) {
   * On Minecraft: Bedrock Edition, servers can additionally verify if you have done the full auth sequence or not, and can kick you if you have not.
   * You will get an error if you don't specify it when calling `getMinecraftJavaToken` or `getMinecraftBedrockToken` when doing device code auth. You can set it to `false` to skip signing.
 * If you just want an Microsoft/Xbox token, you do not need to specify a authTitle.
-* If doing password auth authTitle will not be used and should be removed.
 * If specifying this, you also should provide a `deviceType`, see the doc above
 
 ### What does sisu flow do ?

--- a/examples/bedrock/password.js
+++ b/examples/bedrock/password.js
@@ -1,4 +1,4 @@
-const { Authflow } = require('prismarine-auth')
+const { Authflow, Titles } = require('prismarine-auth')
 const crypto = require('crypto')
 const curve = 'secp384r1'
 
@@ -9,7 +9,7 @@ if (process.argv.length !== 5) {
 
 const keypair = crypto.generateKeyPairSync('ec', { namedCurve: curve }).toString('base64')
 const doAuth = async () => {
-  const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3], flow: 'msal' })
+  const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3], flow: 'live', authTitle: Titles.MinecraftNintendoSwitch })
   const XSTSToken = await flow.getMinecraftBedrockToken(keypair)
   console.log(XSTSToken)
 }

--- a/examples/xbox/password.js
+++ b/examples/xbox/password.js
@@ -6,9 +6,9 @@ if (process.argv.length !== 5) {
 }
 
 const doAuth = async () => {
-  const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3], flow: 'live', authTitle: Titles.MinecraftNintendoSwitch })
-  const response = await flow.getMinecraftJavaToken()
+  const flow = new Authflow(process.argv[2], process.argv[4], { password: process.argv[3], authTitle: Titles.MinecraftNintendoSwitch, flow: 'live' })
+  const response = await flow.getXboxToken()
   console.log(response)
 }
 
-module.exports = doAuth()
+doAuth()

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@azure/msal-node": "^2.0.2",
-    "@xboxreplay/xboxlive-auth": "^3.3.3",
     "debug": "^4.3.3",
     "jose": "^4.1.4",
     "node-fetch": "^2.6.1",

--- a/src/MicrosoftAuthFlow.js
+++ b/src/MicrosoftAuthFlow.js
@@ -121,12 +121,6 @@ class MicrosoftAuthFlow {
       return xstsToken.data
     }
 
-    if (options.password) {
-      debug('[xbl] password is present, trying to authenticate using xboxreplay/xboxlive-auth')
-      const xsts = await this.xbl.doReplayAuth(this.username, options.password, options)
-      return xsts
-    }
-
     debug('[xbl] Need to obtain tokens')
 
     return await retry(async () => {

--- a/src/TokenManagers/LiveTokenManager.js
+++ b/src/TokenManagers/LiveTokenManager.js
@@ -223,7 +223,7 @@ class LiveTokenManager {
 
     // if the response is 200 then we have landed on a "failed" page i.e. Incorrect credentials, new application or a new signin location
     if (response.status === 200) {
-      throw Error(`Coudln't sign in at ${preAuthResponse.url} with email ${email} and password. Please see https://github.com/PrismarineJS/prismarine-auth/blob/master/docs/API.md#why-is-password-auth-unreliable-`)
+      throw Error(`Couldn't sign in at ${preAuthResponse.url} with email ${email} and password. Please see https://github.com/PrismarineJS/prismarine-auth/blob/master/docs/API.md#why-is-password-auth-unreliable-`)
     }
 
     const location = response.headers.get('location')

--- a/src/TokenManagers/XboxTokenManager.js
+++ b/src/TokenManagers/XboxTokenManager.js
@@ -1,6 +1,5 @@
 const crypto = require('crypto')
 
-const XboxLiveAuth = require('@xboxreplay/xboxlive-auth')
 const debug = require('debug')('prismarine-auth')
 const { SmartBuffer } = require('smart-buffer')
 const { exportJWK } = require('jose')
@@ -119,22 +118,6 @@ class XboxTokenManager {
     header.writeBuffer(signature) // Add signature at end of header
 
     return header.toBuffer()
-  }
-
-  async doReplayAuth (email, password, options = {}) {
-    try {
-      const preAuthResponse = await XboxLiveAuth.preAuth()
-      const logUserResponse = await XboxLiveAuth.logUser(preAuthResponse, { email, password })
-      const xblUserToken = await XboxLiveAuth.exchangeRpsTicketForUserToken(logUserResponse.access_token)
-      await this.setCachedToken({ userToken: xblUserToken })
-      debug('[xbl] user token:', xblUserToken)
-      const xsts = await this.getXSTSToken({ userToken: xblUserToken.Token }, options)
-      return xsts
-    } catch (error) {
-      debug('Authentication using a password has failed.')
-      debug(error)
-      throw error
-    }
   }
 
   async doSisuAuth (accessToken, deviceToken, options = {}) {

--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -16,7 +16,8 @@ module.exports = {
     MinecraftServicesProfile: 'https://api.minecraftservices.com/minecraft/profile',
     MinecraftServicesReport: 'https://api.minecraftservices.com/player/report',
     LiveDeviceCodeRequest: 'https://login.live.com/oauth20_connect.srf',
-    LiveTokenRequest: 'https://login.live.com/oauth20_token.srf'
+    LiveTokenRequest: 'https://login.live.com/oauth20_token.srf',
+    LiveTokenAuth: 'https://login.live.com/oauth20_authorize.srf'
   },
   msalConfig: {
     // Initialize msal

--- a/test/password.js
+++ b/test/password.js
@@ -4,11 +4,13 @@ const chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
 const { expect } = chai
 
-const { Authflow } = require('../')
+const { Authflow, Titles } = require('../')
 
-describe('password authentication', async () => {
+const email = 'this.is.not@valid.email.lol'
+
+describe('password authentication', () => {
   it('should fail if not given a valid password', async () => {
-    const flow = new Authflow('this.is.not@valid.email.lol', './test', { password: 'sdfasdfas', flow: 'msal' })
-    await expect(flow.getXboxToken()).to.eventually.be.rejectedWith('Invalid credentials')
-  })
+    const flow = new Authflow(email, './test', { password: 'sdfasdfas', flow: 'live', authTitle: Titles.MinecraftNintendoSwitch })
+    await expect(flow.getXboxToken()).to.be.rejectedWith(Error, `Couldn't sign in at https://login.live.com/oauth20_authorize.srf?client_id=00000000441cc96b&redirect_uri=https%3A%2F%2Flogin.live.com%2Foauth20_desktop.srf&response_type=token&scope=service%3A%3Auser.auth.xboxlive.com%3A%3AMBI_SSL with email ${email} and password. Please see https://github.com/PrismarineJS/prismarine-auth/blob/master/docs/API.md#why-is-password-auth-unreliable-`)
+  }).timeout(10000)
 })


### PR DESCRIPTION
This PR clears up #9 and implements the password method directly within pauth with the added benefit of more descriptive errors i.e. if an account has 2FA enabled. With this change password auth can now do user, device and title authentication enabling developers to use password auth and join servers requiring title auth.

This is a breaking change due to live/sisu flow option needing to be set for password auth to work, it will not work with msal flow.