### PR TITLE
Add a forceRefresh option to Authflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm install prismarine-auth
 - cacheDirectory? {String | Function} - Where we will store your tokens (optional) or a factory function that returns a cache.
 - options {Object?}
     - [flow] {enum} Required if options is specified - see [API.md](docs/API.md) for options
+    - [forceRefresh] {boolean} - Clear all cached tokens for the specified `username` to get new ones on subsequent token requests
     - [password] {string} - If passed we will do password based authentication.
     - [authTitle] {string} - See the [API.md](docs/API.md)
     - [deviceType] {string} - See the [API.md](docs/API.md)

--- a/docs/API.md
+++ b/docs/API.md
@@ -20,6 +20,7 @@ This is the main exposed class you interact with. Every instance holds its own t
   * `password` (optional) If you specify this option, we use password based auth. Note this may be unreliable.
   * `authTitle` - The client ID for the service you are logging into. When using the `msal` flow, this is your custom Azure client token. When using `live`, this is the Windows Live SSO client ID - used when authenticating as a Windows app (such as a vanilla Minecraft client). For a list of titles, see `require('prismarine-auth').Titles` and FAQ section below for more info. (Required if using `sisu` or `live` flow, on `msal` flow we fallback to a default client ID.)
   * `deviceType` (optional) if specifying an authTitle, the device type to auth as. For example, `Win32`, `iOS`, `Android`, `Nintendo`
+  * `forceRefresh` (optional) boolean - Clear all cached tokens for the specified `username` to get new ones on subsequent token requests
 * `codeCallback` (optional) The callback to call when doing device code auth. Otherwise, the code will be logged to the console.
 
 #### getMsaToken () : Promise<string>
@@ -94,6 +95,9 @@ As an example of usage, you could create a minimal in memory cache like this (no
 ```js
 class InMemoryCache {
   private cache = {}
+  async reset () {
+    // (should clear the data in the cache like a first run)
+  }
   async getCached () {
     return this.cache
   }

--- a/examples/xbox/basic.js
+++ b/examples/xbox/basic.js
@@ -1,3 +1,4 @@
 const { Authflow } = require('prismarine-auth')
-const flow = new Authflow() // No parameters needed
+// No parameters needed - will login as Minecraft by default unless a custom Azure client ID is passed (see ./azure.js)
+const flow = new Authflow()
 module.exports = flow.getXboxToken().then(console.log)

--- a/examples/xbox/basic.js
+++ b/examples/xbox/basic.js
@@ -1,4 +1,4 @@
 const { Authflow } = require('prismarine-auth')
 // No parameters needed - will login as Minecraft by default unless a custom Azure client ID is passed (see ./azure.js)
-const flow = new Authflow()
+const flow = new Authflow() 
 module.exports = flow.getXboxToken().then(console.log)

--- a/examples/xbox/basic.js
+++ b/examples/xbox/basic.js
@@ -1,4 +1,4 @@
 const { Authflow } = require('prismarine-auth')
 // No parameters needed - will login as Minecraft by default unless a custom Azure client ID is passed (see ./azure.js)
-const flow = new Authflow() 
+const flow = new Authflow()
 module.exports = flow.getXboxToken().then(console.log)

--- a/index.d.ts
+++ b/index.d.ts
@@ -128,6 +128,7 @@ declare module 'prismarine-auth' {
   }
 
   export interface Cache {
+    reset(): Promise<void>
     getCached(): Promise<any>
     setCached(value: any): Promise<void>
     setCachedPartial(value: any): Promise<void>

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,10 +11,6 @@ declare module 'prismarine-auth' {
      * @param codeCallback Optional callback to recieve token information using device code auth
      */
     constructor(username?: string, cache?: string | CacheFactory, options?: MicrosoftAuthFlowOptions, codeCallback?: (res: ServerDeviceCodeResponse) => void)
-    /**
-     * Deletes the caches in the specified cache directory.
-     */
-    static resetTokenCaches(cache: string): boolean
 
     // Returns a Microsoft Oauth access token -- https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
     getMsaToken(): Promise<string>
@@ -101,6 +97,8 @@ declare module 'prismarine-auth' {
     deviceVersion?: string
     password?: string
     flow: 'live' | 'msal' | 'sisu'
+    // Reset the cache and obtain fresh tokens for everything
+    forceRefresh?: boolean
   }
 
   export enum Titles {

--- a/src/common/cache/FileCache.js
+++ b/src/common/cache/FileCache.js
@@ -5,13 +5,17 @@ class FileCache {
     this.cacheLocation = cacheLocation
   }
 
+  async reset () {
+    const cached = {}
+    fs.writeFileSync(this.cacheLocation, JSON.stringify(cached))
+    return cached
+  }
+
   async loadInitialValue () {
     try {
       return JSON.parse(fs.readFileSync(this.cacheLocation, 'utf8'))
     } catch (e) {
-      const cached = {}
-      fs.writeFileSync(this.cacheLocation, JSON.stringify(cached))
-      return cached
+      return this.reset()
     }
   }
 


### PR DESCRIPTION
- Add a `forceRefresh` boolean option to Authflow
  * Clear all cached tokens for the specified `username` to get new ones on subsequent token requests
- Remove the undocumented `static resetTokenCaches()`