### PR TITLE
Remove jose dependency, fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const userIdentifier = 'any unique identifier'
 const cacheDir = './' // You can leave this as undefined unless you want to specify a caching directory
 const flow = new Authflow(userIdentifier, cacheDir)
 // Get a Minecraft Java Edition auth token, then log it
-flow.getMinecraftJavaToken().then(console.log)
+flow.getMinecraftJavaToken({ fetchProfile: true }).then(console.log)
 ```
 
 ### Expected Response

--- a/package.json
+++ b/package.json
@@ -28,14 +28,13 @@
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "mocha": "^10.0.0",
-    "standard": "^17.0.0",
-    "prismarine-auth": "file:."
+    "prismarine-auth": "file:.",
+    "standard": "^17.0.0"
   },
   "dependencies": {
     "@azure/msal-node": "^2.0.2",
     "@xboxreplay/xboxlive-auth": "^3.3.3",
     "debug": "^4.3.3",
-    "jose": "^4.1.4",
     "node-fetch": "^2.6.1",
     "smart-buffer": "^4.1.0",
     "uuid-1345": "^1.0.2"

--- a/src/TokenManagers/XboxTokenManager.js
+++ b/src/TokenManagers/XboxTokenManager.js
@@ -3,7 +3,6 @@ const crypto = require('crypto')
 const XboxLiveAuth = require('@xboxreplay/xboxlive-auth')
 const debug = require('debug')('prismarine-auth')
 const { SmartBuffer } = require('smart-buffer')
-const { exportJWK } = require('jose')
 const fetch = require('node-fetch')
 
 const { Endpoints, xboxLiveErrors } = require('../common/Constants')
@@ -22,9 +21,7 @@ const checkIfValid = (expires) => {
 class XboxTokenManager {
   constructor (ecKey, cache) {
     this.key = ecKey
-    exportJWK(ecKey.publicKey).then(jwk => {
-      this.jwk = { ...jwk, alg: 'ES256', use: 'sig' }
-    })
+    this.jwk = { ...ecKey.publicKey.export({ format: 'jwk' }), alg: 'ES256', use: 'sig' }
     this.cache = cache
 
     this.headers = { 'Cache-Control': 'no-store, must-revalidate, no-cache', 'x-xbl-contract-version': 1 }


### PR DESCRIPTION
The current implementation of `XboxTokenManager` uses the [`exportJWK`](https://github.com/panva/jose/blob/15a61d4d5987057ee1fc904810c0ab63239f252b/src/key/export.ts#L58C23-L58C32) method of `jose`. Internally, `jose` ensures the type of the provided key to be `KeyObject` (available since Node v11.6.0 and in Bun v1.0.5) and [returns the value of it's `export` method](https://github.com/panva/jose/blob/15a61d4d5987057ee1fc904810c0ab63239f252b/src/runtime/node/key_to_jwk.ts#L35C3-L35C9). This adds overhead and causes compatibility issues (see #95). By directly [calling the export method of the `KeyObject` in the constructor](https://github.com/bluefoxy009/prismarine-auth/blob/5d0d412a146fb65f3ca653055979ccf8cf5dce5b/src/TokenManagers/XboxTokenManager.js#L24), we remove the need for `jose` and achieve compatibility with multiple runtimes. 

The second part of the pull request fixes the example in the README, where `getMinecraftJavaToken` doesn't automatically fetch the profile. The example has been updated to include the option `fetchProfile: true` so the expected response is accurate to what would actually be returned by the example.

This PR closes #88 and #95