### PR TITLE
Supply MSA bearer token directly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ declare module 'prismarine-auth' {
       fetchCertificates?: boolean,
       fetchEntitlements?: boolean
       fetchProfile?: boolean
+      msaToken?: string
     }): Promise<{ token: string, entitlements: MinecraftJavaLicenses, profile: MinecraftJavaProfile, certificates: MinecraftJavaCertificates }>
     // Returns a Minecraft Bedrock Edition auth token. Public key parameter must be a KeyLike object.
     getMinecraftBedrockToken(publicKey: KeyObject): Promise<string>


### PR DESCRIPTION
This PR enables one to supply the MSA bearer token directly (which simplifies a lot for users who do not want to rely on the cache system)

https://github.com/PrismarineJS/node-minecraft-protocol/pull/1323 enables easy access for bot:

```js
const bot = mineflayer.createBot({
  ...
  auth: 'microsoft',
  msaToken: 'abcd...'
})
```